### PR TITLE
Changed the option '--async' to '--nowait' because of a conflict with…

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -289,7 +289,7 @@ Optional arguments
 
   The stage on which to run the function. Defaults to the development stage.
 
-- ``--async``
+- ``--nowait``
 
   Invoke the function, but don't wait for it to run.
 

--- a/slam/cli.py
+++ b/slam/cli.py
@@ -115,9 +115,9 @@ def init(name, description, bucket, timeout, memory, stages, requirements,
                          'dashes are allowed.'.format(name))
     if not bucket:
         random_suffix = ''.join(
-            random.choice(string.ascii_uppercase + string.digits)
+            random.choice(string.ascii_lowercase + string.digits)
             for n in range(8))
-        bucket = '{}-{}'.format(name, random_suffix)
+        bucket = '{}-{}'.format(name.lower(), random_suffix)
 
     stages = [s.strip() for s in stages.split(',')]
 

--- a/slam/cli.py
+++ b/slam/cli.py
@@ -512,11 +512,11 @@ def publish(version, stage, config_file):
                       'structures.')
 @climax.argument('--dry-run', action='store_true',
                  help='Just check that the function can be invoked.')
-@climax.argument('--async', action='store_true',
+@climax.argument('--nowait', action='store_true',
                  help='Invoke the function but don\'t wait for it to return.')
 @climax.argument('--stage', help='Stage of the invoked function. Defaults to '
                                  'the development stage')
-def invoke(stage, async, dry_run, config_file, args):
+def invoke(stage, nowait, dry_run, config_file, args):
     """Invoke the lambda function."""
     config = _load_config(config_file)
     if stage is None:
@@ -533,7 +533,7 @@ def invoke(stage, async, dry_run, config_file, args):
 
     if dry_run:
         invocation_type = 'DryRun'
-    elif async:
+    elif nowait:
         invocation_type = 'Event'
     else:
         invocation_type = 'RequestResponse'

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -94,7 +94,7 @@ class InvokeTests(unittest.TestCase):
 
     @mock.patch('slam.cli.boto3.client')
     @mock.patch('slam.cli._load_config', return_value=config)
-    def test_invoke_async(self, _load_config, client):
+    def test_invoke_nowait(self, _load_config, client):
         mock_cfn = mock.MagicMock()
         mock_lmb = mock.MagicMock()
         mock_cfn.describe_stacks.return_value = describe_stacks_response
@@ -102,7 +102,7 @@ class InvokeTests(unittest.TestCase):
                                         'Payload': BytesIO(b'')}
         client.side_effect = [mock_cfn, mock_lmb]
 
-        cli.main(['invoke', '--async'])
+        cli.main(['invoke', '--nowait'])
         mock_cfn.describe_stacks.assert_called_once_with(StackName='foo')
         mock_lmb.invoke.assert_called_once_with(
             FunctionName='arn:lambda:foo', InvocationType='Event',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py27,py34,py35,py36,docs
+envlist = flake8,py27,py34,py35,py36,py37,py38,docs
 skip_missing_interpreters=True
 
 [testenv]
@@ -34,6 +34,12 @@ basepython = python3.5
 
 [testenv:py36]
 basepython = python3.6
+
+[testenv:py37]
+basepython = python3.7
+
+[testenv:py38]
+basepython = python3.8
 
 [testenv:docs]
 basepython = python2.7


### PR DESCRIPTION
… the Python 3.7 'async' keyword. Added Python 3.7 and 3.8 environments to tox.ini to test the changes.