### PR TITLE
Removes an annoying warning about using yaml.load(...)

### DIFF
--- a/slam/cli.py
+++ b/slam/cli.py
@@ -71,7 +71,7 @@ def on_unexpected_error(e):  # pragma: no cover
 def _load_config(config_file='slam.yaml'):
     try:
         with open(config_file) as f:
-            return yaml.load(f)
+            return yaml.load(f, Loader=yaml.FullLoader)
     except IOError:
         # there is no config file in the current directory
         raise RuntimeError('Config file {} not found. Did you run '

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -28,7 +28,7 @@ class InitTests(unittest.TestCase):
     def test_init_with_defaults(self):
         cli.main(['init', 'app_module:app'])
         with open('slam.yaml') as f:
-            cfg = yaml.load(f)
+            cfg = yaml.load(f, Loader=yaml.FullLoader)
         self.assertEqual(cfg['function']['module'], 'app_module')
         self.assertEqual(cfg['function']['app'], 'app')
         self.assertEqual(cfg['devstage'], 'dev')
@@ -44,7 +44,7 @@ class InitTests(unittest.TestCase):
     def test_init_with_name(self):
         cli.main(['init', '--name', 'foo-bar', 'app_module:app'])
         with open('slam.yaml') as f:
-            cfg = yaml.load(f)
+            cfg = yaml.load(f, Loader=yaml.FullLoader)
         self.assertEqual(cfg['function']['module'], 'app_module')
         self.assertEqual(cfg['function']['app'], 'app')
         self.assertEqual(cfg['name'], 'foo-bar')
@@ -53,7 +53,7 @@ class InitTests(unittest.TestCase):
     def test_init_with_bucket(self):
         cli.main(['init', '--bucket', 'foo-bar', 'app_module:app'])
         with open('slam.yaml') as f:
-            cfg = yaml.load(f)
+            cfg = yaml.load(f, Loader=yaml.FullLoader)
         self.assertEqual(cfg['function']['module'], 'app_module')
         self.assertEqual(cfg['function']['app'], 'app')
         self.assertEqual(cfg['name'], 'app-module')
@@ -62,13 +62,13 @@ class InitTests(unittest.TestCase):
     def test_init_with_requirements(self):
         cli.main(['init', '--requirements', 'foo.txt', 'app_module:app'])
         with open('slam.yaml') as f:
-            cfg = yaml.load(f)
+            cfg = yaml.load(f, Loader=yaml.FullLoader)
         self.assertEqual(cfg['requirements'], 'foo.txt')
 
     def test_init_with_stages(self):
         cli.main(['init', '--stages', 'd,s, p', 'app_module:app'])
         with open('slam.yaml') as f:
-            cfg = yaml.load(f)
+            cfg = yaml.load(f, Loader=yaml.FullLoader)
         self.assertEqual(cfg['devstage'], 'd')
         self.assertEqual(cfg['stage_environments'],
                          {'d': None, 's': None, 'p': None})
@@ -76,13 +76,13 @@ class InitTests(unittest.TestCase):
     def test_init_with_runtime(self):
         cli.main(['init', '--runtime', 'foo', 'app_module:app'])
         with open('slam.yaml') as f:
-            cfg = yaml.load(f)
+            cfg = yaml.load(f, Loader=yaml.FullLoader)
         self.assertEqual(cfg['aws']['lambda_runtime'], 'foo')
 
     def test_init_with_tables(self):
         cli.main(['init', '--dynamodb-tables', 'a,b, c', 'app_module:app'])
         with open('slam.yaml') as f:
-            cfg = yaml.load(f)
+            cfg = yaml.load(f, Loader=yaml.FullLoader)
         t = {'attributes': {'id': 'S'}, 'key': 'id',
              'read_throughput': 1, 'write_throughput': 1}
         self.assertEqual(cfg['dynamodb_tables'], {'a': t, 'b': t, 'c': t})


### PR DESCRIPTION
Removes an annoying warning: 

"YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details."

Changes yaml.load(...) to yaml.load(..., Loader=yaml.FullLoader) because yaml.FullLoader is the 'Loader' used as the default anyway so it shouldn't change anything except killing the warning.   